### PR TITLE
Allow enabling/disabling the start container hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,13 @@ if( ENABLE_LTO )
     endif()
 endif()
 
+# Enable the start container hook (disabled by default)
+option(USE_STARTCONTAINER_HOOK "Enable the startContainer OCI hook in RDK plugins" OFF)
+if(USE_STARTCONTAINER_HOOK)
+    message("Enabled startcontainerhook")
+    add_definitions( -DUSE_STARTCONTAINER_HOOK )
+endif()
+
 # Import AppInfrastructure code
 add_subdirectory( AppInfrastructure/Logging )
 add_subdirectory( AppInfrastructure/Tracing )

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If the schema files in the `bundle/runtime-schemas` directory are changed, then 
 * `-DENABLE_PERFETTO_TRACING=[ON|OFF]` - option to enable or disable Perfetto tracing. Can not be enabled for release builds.
 * `-DDOBBY_SERVICE=""` - specify the Dobby dbus service name. Defaults to `org.rdk.dobby` if none specified.
 * `-DDOBBY_OBJECT=""` - specify the Dobby dbus object path. Defaults to `/org/rdk/dobby` if none specified.
+* `-DUSE_STARTCONTAINER_HOOK=[ON|OFF]` - whether to use the startcontainer OCI hook or not. Defaults to OFF.
 
 In addition to all the above, each RDK plugin has a setting for enabling it for builds. The `Logging`, `Networking`, `IPC` and `Storage` plugins are enabled by default.
 

--- a/bundle/lib/source/DobbyConfig.cpp
+++ b/bundle/lib/source/DobbyConfig.cpp
@@ -493,7 +493,7 @@ void DobbyConfig::addPluginLauncherHooks(std::shared_ptr<rt_dobby_schema> cfg, c
     cfg->hooks->poststop = (rt_defs_hook**)realloc(cfg->hooks->poststop, sizeof(rt_defs_hook*) * ++cfg->hooks->poststop_len);
     cfg->hooks->poststop[cfg->hooks->poststop_len-1] = poststopEntry;
 
-
+#ifdef USE_STARTCONTAINER_HOOK
     // startContainer hook paths must resolve in the container namespace,
     // config is in container rootdir
     configPath = "/tmp/config.json";
@@ -503,6 +503,7 @@ void DobbyConfig::addPluginLauncherHooks(std::shared_ptr<rt_dobby_schema> cfg, c
     setPluginHookEntry(startContainerEntry, "startContainer", configPath);
     cfg->hooks->start_container = (rt_defs_hook**)realloc(cfg->hooks->start_container, sizeof(rt_defs_hook*) * ++cfg->hooks->start_container_len);
     cfg->hooks->start_container[cfg->hooks->start_container_len-1] = startContainerEntry;
+#endif
 }
 
 // -----------------------------------------------------------------------------
@@ -525,6 +526,7 @@ bool DobbyConfig::updateBundleConfig(const ContainerId& id, std::shared_ptr<rt_d
     // if there are any rdk plugins, set up DobbyPluginLauncher in config
     if (cfg->rdk_plugins->plugins_count)
     {
+#ifdef USE_STARTCONTAINER_HOOK
         // bindmount DobbyPluginLauncher to container
         if(!addMount(PLUGINLAUNCHER_PATH, PLUGINLAUNCHER_PATH, "bind", 0,
                         { "bind", "ro", "nosuid", "nodev" }))
@@ -538,6 +540,7 @@ bool DobbyConfig::updateBundleConfig(const ContainerId& id, std::shared_ptr<rt_d
         {
             return false;
         }
+#endif
 
         // set up OCI hooks to use DobbyPluginLauncher
         addPluginLauncherHooks(cfg, bundlePath);

--- a/pluginLauncher/lib/include/IDobbyRdkPlugin.h
+++ b/pluginLauncher/lib/include/IDobbyRdkPlugin.h
@@ -68,7 +68,9 @@ public:
         PreCreationFlag = (1 << 1),
         CreateRuntimeFlag = (1 << 2),
         CreateContainerFlag = (1 << 3),
+#ifdef USE_STARTCONTAINER_HOOK
         StartContainerFlag = (1 << 4),
+#endif
         PostStartFlag = (1 << 5),
         PostHaltFlag = (1 << 6),
         PostStopFlag = (1 << 7),
@@ -103,8 +105,10 @@ public:
     // OCI Hook
     virtual bool createContainer() = 0;
 
+#ifdef USE_STARTCONTAINER_HOOK
     // OCI Hook
     virtual bool startContainer() = 0;
+#endif
 
     // OCI Hook
     virtual bool postStart() = 0;

--- a/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
+++ b/pluginLauncher/lib/source/DobbyRdkPluginManager.cpp
@@ -507,8 +507,10 @@ bool DobbyRdkPluginManager::executeHook(const std::string &pluginName,
         return plugin->createContainer();
     case IDobbyRdkPlugin::HintFlags::CreateRuntimeFlag:
         return plugin->createRuntime();
+#ifdef USE_STARTCONTAINER_HOOK
     case IDobbyRdkPlugin::HintFlags::StartContainerFlag:
         return plugin->startContainer();
+#endif
     case IDobbyRdkPlugin::HintFlags::PostStartFlag:
         return plugin->postStart();
     case IDobbyRdkPlugin::HintFlags::PostHaltFlag:
@@ -552,9 +554,11 @@ bool DobbyRdkPluginManager::runPlugins(const IDobbyRdkPlugin::HintFlags &hookPoi
     case IDobbyRdkPlugin::HintFlags::CreateRuntimeFlag:
         hookName = "createRuntime";
         break;
+#ifdef USE_STARTCONTAINER_HOOK
     case IDobbyRdkPlugin::HintFlags::StartContainerFlag:
         hookName = "startContainer";
         break;
+#endif
     case IDobbyRdkPlugin::HintFlags::PostStartFlag:
         hookName = "postStart";
         break;

--- a/pluginLauncher/tool/source/Main.cpp
+++ b/pluginLauncher/tool/source/Main.cpp
@@ -131,7 +131,9 @@ IDobbyRdkPlugin::HintFlags determineHookPoint(const std::string &hookName)
             {"preCreation", IDobbyRdkPlugin::HintFlags::PreCreationFlag},
             {"createruntime", IDobbyRdkPlugin::HintFlags::CreateRuntimeFlag},
             {"createcontainer", IDobbyRdkPlugin::HintFlags::CreateContainerFlag},
+#ifdef USE_STARTCONTAINER_HOOK
             {"startcontainer", IDobbyRdkPlugin::HintFlags::StartContainerFlag},
+#endif
             {"poststart", IDobbyRdkPlugin::HintFlags::PostStartFlag},
             {"posthalt", IDobbyRdkPlugin::HintFlags::PostHaltFlag},
             {"poststop", IDobbyRdkPlugin::HintFlags::PostStopFlag}};

--- a/rdkPlugins/Common/include/DobbyLoggerBase.h
+++ b/rdkPlugins/Common/include/DobbyLoggerBase.h
@@ -106,6 +106,7 @@ public:
         return true;
     };
 
+#ifdef USE_STARTCONTAINER_HOOK
     /**
      * Hook Name: startContainer
      * Hook Execution Namespace: container
@@ -124,6 +125,7 @@ public:
     {
         return true;
     };
+#endif
 
     /**
      * Hook Name: postStart

--- a/rdkPlugins/Common/include/RdkPluginBase.h
+++ b/rdkPlugins/Common/include/RdkPluginBase.h
@@ -114,6 +114,7 @@ public:
         return true;
     };
 
+#ifdef USE_STARTCONTAINER_HOOK
     /**
      * Hook Name: startContainer
      * Hook Execution Namespace: container
@@ -132,6 +133,7 @@ public:
     {
         return true;
     };
+#endif
 
     /**
      * Hook Name: postStart

--- a/rdkPlugins/TestPlugin/source/TestRdkPlugin.cpp
+++ b/rdkPlugins/TestPlugin/source/TestRdkPlugin.cpp
@@ -58,7 +58,9 @@ unsigned TestRdkPlugin::hookHints() const
         IDobbyRdkPlugin::HintFlags::PreCreationFlag |
         IDobbyRdkPlugin::HintFlags::CreateRuntimeFlag |
         IDobbyRdkPlugin::HintFlags::CreateContainerFlag |
+#ifdef USE_STARTCONTAINER_HOOK
         IDobbyRdkPlugin::HintFlags::StartContainerFlag |
+#endif
         IDobbyRdkPlugin::HintFlags::PostStartFlag |
         IDobbyRdkPlugin::HintFlags::PostHaltFlag |
         IDobbyRdkPlugin::HintFlags::PostStopFlag);

--- a/rdkPlugins/TestPlugin/source/TestRdkPlugin.h
+++ b/rdkPlugins/TestPlugin/source/TestRdkPlugin.h
@@ -67,7 +67,9 @@ public:
 
     bool createContainer() override;
 
+#ifdef USE_STARTCONTAINER_HOOK
     bool startContainer() override;
+#endif
 
     bool postStart() override;
 


### PR DESCRIPTION
Hook is not used by any existing plugins and causes issues with library dependencies inside containers

### Description
What does this PR change/fix and why?

If there is a corresponding JIRA ticket, please ensure it is in the title of the PR.

### Test Procedure
How to test this PR (if applicable)

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (doesn't fit into the above categories - e.g. documentation updates)

### Requires Bitbake Recipe changes?
- [ ] The base Bitbake recipe (`meta-rdk-ext/recipes-containers/dobby/dobby.bb`) must be modified to support the changes in this PR (beyond updating `SRC_REV`)